### PR TITLE
Fix for an install issue for Chinese versions

### DIFF
--- a/iwdification/sfo/rebuild_spell_hotkeys.tph
+++ b/iwdification/sfo/rebuild_spell_hotkeys.tph
@@ -76,7 +76,7 @@ BEGIN
 		END
 		""
 		SET found_first=0
-		REPLACE_EVALUATE "{ +[0-9]+, +6, +'\(SPWI[0-9]+\)" BEGIN
+		REPLACE_EVALUATE "{ +[0-9]+, +6, +\('SPWI[0-9]+\)" BEGIN
 			PATCH_IF !found_first BEGIN
 				SET found_first=1
 				SPRINT first_mage_spell "%MATCH1%"


### PR DESCRIPTION
Fix for an issue where installing the IWD Spell Components would corrupt the bgee.lua file on Chinese versions.